### PR TITLE
fix(views): update group_id references to use estimate_group_id for c…

### DIFF
--- a/app/Http/Controllers/EstimateController.php
+++ b/app/Http/Controllers/EstimateController.php
@@ -2457,6 +2457,19 @@ class EstimateController extends Controller
                             }
                         }
 
+                        foreach ($proposalData['estimate_items'] as &$item) {
+                            if ($item['estimate_id'] == $id && $item['estimate_group_id'] == $groupId) {
+                                $item['upgrade_status'] = $status;
+
+                                // Update upgrade_status in DB
+                                $dbItem = EstimateItem::find($item['estimate_item_id']);
+                                if ($dbItem) {
+                                    $dbItem->upgrade_status = $status;
+                                    $dbItem->save();
+                                }
+                            }
+                        }
+
                         // Update include_est_total for both global groups and estimate-specific groups
                         if ($type === 'acceptAll' || $type === 'rejectAll') {
                             // First try to find estimate-specific group

--- a/resources/views/accept-proposal.blade.php
+++ b/resources/views/accept-proposal.blade.php
@@ -219,9 +219,9 @@
                                                     $groupTotal += $item['item_total'];
                                                 }
                                                 @endphp
-                                                @if(!empty($group) && !in_array($group['group_id'], $displayedGroups))
+                                                @if(!empty($group) && !in_array($group['estimate_group_id'] ?? $group['group_id'], $displayedGroups))
                                                 @php
-                                                $displayedGroups[] = $group['group_id'];
+                                                $displayedGroups[] = $group['estimate_group_id'] ?? $group['group_id'];
                                                 @endphp
                                                 @endif
                                                 @endforeach
@@ -229,16 +229,16 @@
                                                 <div class="w-full flex justify-between">
                                                     <div id="cuttingDiv">
                                                         <h1 class="font-bold text-xl my-auto p-2 underline">{{$groupName}}</h1>
-                                                        <input type="hidden" class="group-total" data-group-id="{{$item['group_id']}}" value="{{$groupTotal}}">
+                                                        <input type="hidden" class="group-total" data-group-id="{{$item['estimate_group_id'] ?? $item['group_id']}}" value="{{$groupTotal}}">
                                                     </div>
                                                     @if(isset($item['group']['include_est_total']) && $item['group']['include_est_total'] == 0)
                                                     <div class="my-auto mx-2 text-lg">
                                                         <div class="inline-block p-3 rounded-md bg-green-100">
                                                             <input type="radio"
-                                                            name="group_accept_reject_{{$item['group_id']}}"
+                                                            name="group_accept_reject_{{$item['estimate_group_id'] ?? $item['group_id']}}"
                                                             value="accepted"
                                                             class="group-radio"
-                                                            data-group-id="{{$item['group_id']}}"
+                                                            data-group-id="{{$item['estimate_group_id'] ?? $item['group_id']}}"
                                                             data-proposal-id="{{$proposal_id}}"
                                                             {{ $item['upgrade_status'] == 'accepted' ? 'checked' : '' }}>
                                                             <label class="text-green-800">Accept</label>
@@ -246,10 +246,10 @@
                                                         |
                                                         <div class="inline-block p-3 rounded-md bg-red-100">
                                                             <input type="radio"
-                                                                name="group_accept_reject_{{$item['group_id']}}"
+                                                                name="group_accept_reject_{{$item['estimate_group_id'] ?? $item['group_id']}}"
                                                                 value="rejected"
                                                                 class="group-radio"
-                                                                data-group-id="{{$item['group_id']}}"
+                                                                data-group-id="{{$item['estimate_group_id'] ?? $item['group_id']}}"
                                                                 data-proposal-id="{{$proposal_id}}"
                                                                 {{ $item['upgrade_status'] == 'rejected' ? 'checked' : '' }}>
                                                             <label class="text-red-800">Reject</label>
@@ -299,10 +299,6 @@
                                                     @endphp
                                                     @foreach ($itemss as $item)
                                                     <tr class="bg-white border-b">
-                                                        <!-- <th scope="row" class="px-6 font-medium text-gray-900 whitespace-nowrap">
-                                                        <input type="checkbox" disabled name="privileges[reports][view]" id="privilegeReportsView">
-                                                        <label for="privilegeReportsView" class=" text-gray-500"></label>
-                                                    </th> -->
                                                         @php
                                                         $showQty = $item['group'] && $item['group']['show_quantity'] == 1;
                                                         $showTotal = $item['group'] && $item['group']['show_total'] == 1;
@@ -412,10 +408,6 @@
                                                 $itemName = App\Models\Items::where('item_id', $item['item_id'])->first();
                                                 @endphp
                                                 <tr class="bg-white border-b">
-                                                    <!-- <td class="px-6 py-4">
-                                                    <input type="checkbox" disabled name="privileges[reports][view]" id="privilegeReportsView">
-                                                    <label for="privilegeReportsView" class=" text-gray-500"></label>
-                                                </td> -->
                                                     <td class="px-6 py-4">
                                                         <label class="text-lg font-semibold text-[#323C47]" for="">{{ $itemName->item_name }}</label>
                                                     </td>
@@ -476,10 +468,6 @@
                                             <tbody>
                                                 @foreach($upgrades as $upgrade)
                                                 <tr class="bg-white border-b">
-                                                    <!-- <th scope="row" class="px-6 font-medium text-gray-900 whitespace-nowrap">
-                                                    <input type="checkbox" disabled name="privileges[reports][view]" id="privilegeReportsView">
-                                                    <label for="privilegeReportsView" class=" text-gray-500"></label>
-                                                </th> -->
                                                     <td class="px-6 py-4">
                                                         <label class="text-lg font-semibold text-[#323C47]" for="">{{ $upgrade->item_name }}</label>
                                                         <p class="text-[16px]/[18px] text-[#323C47] font">
@@ -614,9 +602,6 @@
                                     $discountedTotal = null;
                                     }
                                     @endphp
-                                    {{-- <p class="text-[#858585]">
-                                        ${{ number_format($discountedTotal, 2) }}
-                                    </p> --}}
                                 </div>
                             </div>
                         </div>

--- a/resources/views/previousProposal.blade.php
+++ b/resources/views/previousProposal.blade.php
@@ -238,20 +238,20 @@ body {
                                                 @php
                                                 $group = $item['group']; // Get group details
                                                 @endphp
-                                                @if(!empty($group) && !in_array($group['group_id'], $displayedGroups))
+                                                @if(!empty($group) && !in_array($group['estimate_group_id'] ?? $group['group_id'], $displayedGroups))
                                                 <!-- Display edit button only if the group has not been displayed before -->
                                                 @php
-                                                $displayedGroups[] = $group['group_id']; // Add group to displayed groups
+                                                $displayedGroups[] = $group['estimate_group_id'] ?? $group['group_id']; // Add group to displayed groups
                                                 @endphp
                                                 @endif
                                                 @endforeach
                                                 <div class="w-full flex justify-between">
                                                     <div id="cuttingDiv">
                                                         <h1 class=" font-bold text-xl my-auto p-2 underline">{{$groupName}}</h1>
-                                                        <div id="formData{{$item['group_id']}}" class="hidden">
+                                                        <div id="formData{{$item['estimate_group_id'] ?? $item['group_id']}}" class="hidden">
                                                             @csrf
                                                             <input type="hidden" name="estimate_id" value="{{$estimate['estimate_id']}}">
-                                                            <input type="hidden" name="group_id" value="{{$item['group_id']}}">
+                                                            <input type="hidden" name="group_id" value="{{$item['estimate_group_id'] ?? $item['group_id']}}">
                                                             <input type="hidden" name="type" value="acceptAll">
                                                             <input type="hidden" name="item_status" value="accepted">
                                                             <input type="hidden" name="estimate_item_id" value="">
@@ -263,7 +263,7 @@ body {
                                                             type="radio"
                                                             name="group_accept_reject"
                                                             value="accepted"
-                                                            id="submitAcceptionRejection{{$item->group_id}}"
+                                                            id="submitAcceptionRejection{{$item['estimate_group_id'] ?? $item['group_id']}}"
                                                             data-type="acceptAll"
                                                             data-status="accepted"
                                                             {{ $item->upgrade_status == 'accepted' ? 'checked' : '' }}>
@@ -273,7 +273,7 @@ body {
                                                             type="radio"
                                                             name="group_accept_reject"
                                                             value="rejected"
-                                                            id="submitAcceptionRejection{{$item->group_id}}"
+                                                            id="submitAcceptionRejection{{$item['estimate_group_id'] ?? $item['group_id']}}"
                                                             data-type="rejectAll"
                                                             data-status="rejected"
                                                             {{ $item->upgrade_status == 'rejected' ? 'checked' : '' }}>


### PR DESCRIPTION
…onsistency

- Modified references in accept-proposal and previousProposal views to utilize estimate_group_id where applicable.
- Ensured that group handling is consistent across both views, improving data integrity and tracking.