### PR TITLE
fix(views): correct conditional check for group total inclusion in vi…

### DIFF
--- a/resources/views/viewEstimateMaterials.blade.php
+++ b/resources/views/viewEstimateMaterials.blade.php
@@ -270,7 +270,7 @@ h1, h2, h3, h4, h5 {
                 @if ( $estimate_items->count() > 0)
 
                     @foreach ($groupedItems as $groupName => $itemss)
-                    @if (($itemss[0]->group->include_est_total ?? 0) !== 0)
+                    @if (($itemss[0]->group->include_est_total ?? 0) != 0)
                         <div class="mb-2 bg-white  group-section">
                         <!-- Group Header - Keep with content if possible -->
                         <div class="p-1 text-black w-full rounded-t-lg group-header">


### PR DESCRIPTION
…ewEstimateMaterials

- Updated the conditional check for group total inclusion from strict comparison to loose comparison to ensure proper evaluation of the include_est_total property.