### PR TITLE
fix(ApiController): correct group assignment in estimate item update

### DIFF
--- a/app/Http/Controllers/api/ApiController.php
+++ b/app/Http/Controllers/api/ApiController.php
@@ -3814,29 +3814,27 @@ class ApiController extends Controller
             $estimateItem = EstimateItem::where('estimate_item_id', $validatedData['item_id'])->first();
             $estimateItemAssembly = EstimateItemAssembly::where('estimate_item_id', $estimateItem->estimate_item_id)->get();
             if (isset($validatedData['group_name']) && $validatedData['group_name'] != null) {
-                // Create or get estimate-specific group
                 $groupDetail = EstimateGroups::getOrCreate(
                     $validatedData['estimate_id'],
                     $validatedData['group_name'],
                     $userDetails->id
                 );
-                $groupId = null;
-                $estimateItem = $groupDetail->estimate_group_id;
+                $groupId = $groupDetail->estimate_group_id;
             } else {
-                    $groupDetail = EstimateGroups::create([
-                        'group_name' => 'Single',
-                        'group_type' => 'assemblies',
-                        'show_unit_price' => 1,
-                        'show_quantity' => 1,
-                        'show_total' => 1,
-                        'show_group_total' => 1,
-                        'include_est_total' => 1,
-                        'added_user_id' => $userDetails->id
-                    ]);
-                $groupId = null;
-                $estimateItem = $groupDetail->estimate_group_id;
+                $groupDetail = EstimateGroups::create([
+                    'group_name' => 'Single',
+                    'group_type' => 'assemblies',
+                    'show_unit_price' => 1,
+                    'show_quantity' => 1,
+                    'show_total' => 1,
+                    'show_group_total' => 1,
+                    'include_est_total' => 1,
+                    'added_user_id' => $userDetails->id
+                ]);
+                $groupId = $groupDetail->estimate_group_id;
             }
-
+            
+            $estimateItem->estimate_group_id = $groupId;
             $estimateItem->item_name = $validatedData['item_name'];
             $estimateItem->item_unit = $validatedData['item_units'];
             $estimateItem->labour_expense = $validatedData['labour_expense'];


### PR DESCRIPTION
Fix incorrect variable assignment where $estimateItem was being overwritten instead of setting estimate_group_id. Also clean up redundant code and improve consistency in group creation logic.