### PR TITLE
fix: use correct model class EstimateGroups instead of Groups

### DIFF
--- a/app/Http/Controllers/EstimateController.php
+++ b/app/Http/Controllers/EstimateController.php
@@ -3343,7 +3343,7 @@ class EstimateController extends Controller
                 $groupId = null;
                 $estimateGroupId = $groupDetail->estimate_group_id;
             } else {
-                    $groupDetail = Groups::create([
+                    $groupDetail = EstimateGroups::create([
                         'group_name' => 'Single',
                         'group_type' => 'assemblies',
                         'show_unit_price' => 1,


### PR DESCRIPTION
The Groups model was incorrectly used when creating estimate groups. Changed to use the correct EstimateGroups model to ensure proper data persistence.